### PR TITLE
Fix TypeScript build error by removing .ts import extensions

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -2,8 +2,8 @@ import express from "express";
 import cors from "cors";
 import morgan from "morgan";
 
-import customerRoutes from "./routes/customers.ts";   // ← add .ts
-import invoiceRoutes  from "./routes/invoices.ts";    // ← add .ts
+import customerRoutes from "./routes/customers";
+import invoiceRoutes from "./routes/invoices";
 // (add .ts if you later import jobs.ts, materials.ts, etc.)
 
 const app = express();

--- a/backend/src/routes/customers.ts
+++ b/backend/src/routes/customers.ts
@@ -1,5 +1,5 @@
 import { Router } from "express";
-import prisma from "../prismaClient.ts";   // ← path to the Prisma client helper
+import prisma from "../prismaClient";
 
 const r = Router();
 

--- a/backend/src/routes/invoices.ts
+++ b/backend/src/routes/invoices.ts
@@ -1,5 +1,5 @@
 import { Router } from "express";
-import prisma from "../prismaClient.ts";
+import prisma from "../prismaClient";
 const r = Router();
 
 r.get("/", async (_, res) => {

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -1,3 +1,3 @@
-import app from "./app.ts";      // ← include .ts
+import app from "./app";
 const PORT = process.env.PORT || 4000;
 app.listen(PORT, () => console.log(`API ready on http://localhost:${PORT}`));


### PR DESCRIPTION
## Summary
- remove `.ts` extensions from backend imports so `tsc` can build

## Testing
- `pnpm build` *(fails: Could not find declaration file for module 'cors', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68473d144d10832fb96f21a564d3676e