### PR TITLE
Add simple navigation home page

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,5 @@
 import { Routes, Route, Navigate } from "react-router-dom";
+import Home from "./pages/Home";
 import Dashboard from "./pages/Dashboard";
 import Invoices from "./pages/Invoices";
 
@@ -6,7 +7,8 @@ export default function App() {
   return (
     <div className="min-h-screen p-4">
       <Routes>
-        <Route path="/" element={<Dashboard />} />
+        <Route path="/" element={<Home />} />
+        <Route path="/dashboard" element={<Dashboard />} />
         <Route path="/invoices/*" element={<Invoices />} />
         <Route path="*" element={<Navigate to="/" replace />} />
       </Routes>

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -1,0 +1,17 @@
+import { Link } from "react-router-dom";
+
+export default function Home() {
+  return (
+    <div className="space-y-4">
+      <h1 className="text-2xl font-bold">Welcome to Tax My Backend</h1>
+      <nav className="flex flex-col space-y-2">
+        <Link to="/dashboard" className="text-blue-500 hover:underline">
+          Dashboard
+        </Link>
+        <Link to="/invoices" className="text-blue-500 hover:underline">
+          Invoices
+        </Link>
+      </nav>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add a new Home page with links to other sections
- update routing so the dashboard is at `/dashboard`

## Testing
- `pnpm -r build` *(fails: vite permission denied)*
- `pnpm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68473f4bbe20832f8b95e4f1040f81a8