### PR TITLE
Add feedback page

### DIFF
--- a/.env
+++ b/.env
@@ -1,2 +1,5 @@
 # For SQLite dev
 DATABASE_URL="file:./dev.db"
+
+# Webhook for feedback submissions
+VITE_FEEDBACK_WEBHOOK_URL="https://hooks.zapier.com/hooks/catch/9663424/uyha48y/"

--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,5 @@
 # For SQLite dev
 DATABASE_URL="file:./dev.db"
+
+# Webhook for feedback submissions
+VITE_FEEDBACK_WEBHOOK_URL="https://hooks.zapier.com/hooks/catch/9663424/uyha48y/"

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2,6 +2,7 @@ import { Routes, Route, Navigate } from "react-router-dom";
 import Home from "./pages/Home";
 import Dashboard from "./pages/Dashboard";
 import Invoices from "./pages/Invoices";
+import Feedback from "./pages/Feedback";
 
 export default function App() {
   return (
@@ -10,6 +11,7 @@ export default function App() {
         <Route path="/" element={<Home />} />
         <Route path="/dashboard" element={<Dashboard />} />
         <Route path="/invoices/*" element={<Invoices />} />
+        <Route path="/feedback" element={<Feedback />} />
         <Route path="*" element={<Navigate to="/" replace />} />
       </Routes>
     </div>

--- a/frontend/src/pages/Feedback.tsx
+++ b/frontend/src/pages/Feedback.tsx
@@ -1,0 +1,70 @@
+import { useState } from "react";
+
+export default function Feedback() {
+  const [type, setType] = useState("bug");
+  const [description, setDescription] = useState("");
+  const [status, setStatus] = useState<"idle" | "loading" | "success" | "error">("idle");
+
+  const webhookUrl =
+    import.meta.env.VITE_FEEDBACK_WEBHOOK_URL ||
+    "https://hooks.zapier.com/hooks/catch/9663424/uyha48y/";
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setStatus("loading");
+    try {
+      await fetch(webhookUrl, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ type, description })
+      });
+      setDescription("");
+      setType("bug");
+      setStatus("success");
+    } catch {
+      setStatus("error");
+    }
+  };
+
+  return (
+    <div className="max-w-xl mx-auto">
+      <h1 className="text-2xl font-bold mb-4">Feedback</h1>
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <div>
+          <label className="block mb-1 font-medium">Type</label>
+          <select
+            value={type}
+            onChange={(e) => setType(e.target.value)}
+            className="border rounded p-2 w-full"
+          >
+            <option value="bug">Bug</option>
+            <option value="feature">Feature</option>
+          </select>
+        </div>
+        <div>
+          <label className="block mb-1 font-medium">Description</label>
+          <textarea
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+            className="border rounded p-2 w-full"
+            rows={4}
+            required
+          />
+        </div>
+        <button
+          type="submit"
+          className="bg-blue-500 text-white px-4 py-2 rounded"
+          disabled={status === "loading"}
+        >
+          Submit
+        </button>
+        {status === "success" && (
+          <p className="text-green-600">Thank you for your feedback!</p>
+        )}
+        {status === "error" && (
+          <p className="text-red-600">Something went wrong. Please try again.</p>
+        )}
+      </form>
+    </div>
+  );
+}

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -11,6 +11,9 @@ export default function Home() {
         <Link to="/invoices" className="text-blue-500 hover:underline">
           Invoices
         </Link>
+        <Link to="/feedback" className="text-blue-500 hover:underline">
+          Feedback
+        </Link>
       </nav>
     </div>
   );


### PR DESCRIPTION
## Summary
- allow webhook configuration
- add a feedback form page that submits to the webhook
- link feedback page from home
- integrate Zapier webhook URL

## Testing
- `pnpm build` *(fails: Could not find declaration file for module 'cors')*
- `pnpm --filter frontend build` *(fails: vite: Permission denied)*

------
https://chatgpt.com/codex/tasks/task_e_68474036dc3c832f9524b7ebb60193a5