### PR TITLE
Update feedback webhook

### DIFF
--- a/.env
+++ b/.env
@@ -1,2 +1,5 @@
 # For SQLite dev
 DATABASE_URL="file:./dev.db"
+
+# Webhook for feedback submissions
+VITE_FEEDBACK_WEBHOOK_URL="https://hooks.zapier.com/hooks/catch/9663424/uyha48y/"

--- a/.env.example
+++ b/.env.example
@@ -2,4 +2,5 @@
 DATABASE_URL="file:./dev.db"
 
 # Webhook for feedback submissions
-VITE_FEEDBACK_WEBHOOK_URL=""
+# Defaults to Zapier test webhook if not set
+VITE_FEEDBACK_WEBHOOK_URL="https://hooks.zapier.com/hooks/catch/9663424/uyha48y/"

--- a/frontend/src/pages/Feedback.tsx
+++ b/frontend/src/pages/Feedback.tsx
@@ -4,13 +4,16 @@ export default function Feedback() {
   const [type, setType] = useState("bug");
   const [description, setDescription] = useState("");
   const [status, setStatus] = useState<"idle" | "loading" | "success" | "error">("idle");
+  const webhookUrl =
+    import.meta.env.VITE_FEEDBACK_WEBHOOK_URL ||
+    "https://hooks.zapier.com/hooks/catch/9663424/uyha48y/";
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    if (!import.meta.env.VITE_FEEDBACK_WEBHOOK_URL) return;
+    if (!webhookUrl) return;
     setStatus("loading");
     try {
-      await fetch(import.meta.env.VITE_FEEDBACK_WEBHOOK_URL, {
+      await fetch(webhookUrl, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ type, description })


### PR DESCRIPTION
## Summary
- point feedback form to a default Zapier webhook
- set webhook URL in .env and .env.example

## Testing
- `pnpm build` *(fails: missing types in backend)*
- `pnpm --filter frontend exec vite build` *(fails: vite EACCES)*
- `pnpm install` *(fails: ERROR with modules directory)*


------
https://chatgpt.com/codex/tasks/task_e_6847441286a4832fa304545b0587ef6a