### PR TITLE
Route feedback through backend webhook

### DIFF
--- a/.env
+++ b/.env
@@ -2,4 +2,4 @@
 DATABASE_URL="file:./backend/dev.db"
 
 # Webhook for feedback submissions
-VITE_FEEDBACK_WEBHOOK_URL="https://hooks.zapier.com/hooks/catch/9663424/uyha48y/"
+FEEDBACK_WEBHOOK_URL="https://hooks.zapier.com/hooks/catch/9663424/uyha48y/"

--- a/.env.example
+++ b/.env.example
@@ -3,4 +3,4 @@ DATABASE_URL="file:./backend/dev.db"
 
 # Webhook for feedback submissions
 # Defaults to Zapier test webhook if not set
-VITE_FEEDBACK_WEBHOOK_URL="https://hooks.zapier.com/hooks/catch/9663424/uyha48y/"
+FEEDBACK_WEBHOOK_URL="https://hooks.zapier.com/hooks/catch/9663424/uyha48y/"

--- a/backend/src/routes/feedback.ts
+++ b/backend/src/routes/feedback.ts
@@ -26,7 +26,31 @@ r.post("/", async (req, res) => {
     type: string;
     description: string;
   };
-  await prisma.$executeRaw`INSERT INTO Feedback(type, description) VALUES (${type}, ${description})`;
+  try {
+    await prisma.$executeRaw`INSERT INTO Feedback(type, description) VALUES (${type}, ${description})`;
+  } catch (err) {
+    console.error("Failed to store feedback", err);
+    return res.status(500).json({ ok: false, error: "Failed to store feedback" });
+  }
+
+  const webhook = process.env.FEEDBACK_WEBHOOK_URL;
+  if (webhook) {
+    try {
+      const resp = await fetch(webhook, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ type, description }),
+      });
+      if (!resp.ok) {
+        console.error("Webhook responded with", resp.status);
+        return res.status(500).json({ ok: false, error: "Webhook request failed" });
+      }
+    } catch (err) {
+      console.error("Error sending to webhook", err);
+      return res.status(500).json({ ok: false, error: "Webhook request failed" });
+    }
+  }
+
   res.json({ ok: true });
 });
 

--- a/frontend/src/pages/Feedback.tsx
+++ b/frontend/src/pages/Feedback.tsx
@@ -22,7 +22,7 @@ export default function Feedback() {
     e.preventDefault();
     setStatus("loading");
     try {
-      await fetch("https://hooks.zapier.com/hooks/catch/9663424/uyha48y/", {
+      await fetch("/api/feedback", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ type, description })


### PR DESCRIPTION
## Summary
- send stored feedback to `FEEDBACK_WEBHOOK_URL`
- post feedback from frontend directly to `/api/feedback`
- document `FEEDBACK_WEBHOOK_URL` in `.env` files

## Testing
- `pnpm run build` *(fails: Could not find a declaration file for module 'cors')*

------
https://chatgpt.com/codex/tasks/task_e_6847553c0950832fab7d4f52b01184e6